### PR TITLE
Switch to contrast treshold of .6

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ The `text-lightness-offset-10` increases the lightness of the text with 10%. Oth
 
 ## Configuration
 
-If you prefer to change the threshold when the contrast color switches to black or white, you can adjust the value of `contrastThreshold`. This value should be somewhere between `0` and `1`. The higher the number, the more likely white will be chosen as the contrast color.
+If you prefer to change the threshold when the contrast color switches to black or white, you can adjust the value of `contrastThreshold`. This value should be somewhere between `0` and `1`. The higher the number, the more likely white will be chosen as the contrast color. While I was working on this plugin, I noticed that a contrast threshold of `.6` looked better on different screens than `.5`, since dark colors seem to have lesser contrast then lighter colors in reality.
 
 ```js
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   plugins: [require('tailwindcss-oklch')({
-    contrastThreshold: .6,
+    contrastThreshold: .5,
   })],
 }
 ```

--- a/examples/tailwind.config.js
+++ b/examples/tailwind.config.js
@@ -4,9 +4,7 @@ const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
   content: ["index.html"],
-  plugins: [require('./../index.js')({
-    contrastThreshold: .6,
-  })],
+  plugins: [require('./../index.js')()],
   theme: {
     extend: {
       colors: {

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const propertyColors = Object.fromEntries(utilities.map(({ key }) => {
   ];
 }).flat());
 
-export default plugin.withOptions(({ contrastThreshold = 0.5 } = {}) => {
+export default plugin.withOptions(({ contrastThreshold = 0.6 } = {}) => {
   return ({
     matchUtilities, theme, corePlugins, addDefaults,
   }) => {


### PR DESCRIPTION
Turns out `.6` gives better contrast results on screens where black is a bit too light.